### PR TITLE
Update for iOS 8.2

### DIFF
--- a/Nighscout/AppDelegate.m
+++ b/Nighscout/AppDelegate.m
@@ -9,6 +9,7 @@
 #import "AppDelegate.h"
 #import "ViewController.h"
 #import "SettingsManager.h"
+#import <MediaPlayer/MediaPlayer.h>
 #import <AVFoundation/AVFoundation.h>
 
 @interface AppDelegate ()

--- a/Nighscout/Base.lproj/LaunchScreen.xib
+++ b/Nighscout/Base.lproj/LaunchScreen.xib
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="6245" systemVersion="14A389" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="6245" systemVersion="14B25" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES">
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6238"/>
         <capability name="Aspect ratio constraints" minToolsVersion="5.1"/>

--- a/Nighscout/Base.lproj/Main.storyboard
+++ b/Nighscout/Base.lproj/Main.storyboard
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="6245" systemVersion="14B25" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="6724" systemVersion="14C109" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="BYZ-38-t0r">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6238"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6711"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
     </dependencies>
     <scenes>
@@ -21,6 +21,25 @@
                                 <rect key="frame" x="0.0" y="20" width="600" height="500"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                             </webView>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Xhq-O6-s1q">
+                                <rect key="frame" x="5" y="562" width="100" height="30"/>
+                                <color key="backgroundColor" white="0.0" alpha="1" colorSpace="calibratedWhite"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="100" id="syk-hr-2JU"/>
+                                </constraints>
+                                <state key="normal" title="Set URL">
+                                    <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                    <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                                </state>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                        <integer key="value" value="3"/>
+                                    </userDefinedRuntimeAttribute>
+                                </userDefinedRuntimeAttributes>
+                                <connections>
+                                    <action selector="updateUrl:" destination="BYZ-38-t0r" eventType="touchUpInside" id="te0-L5-tRB"/>
+                                </connections>
+                            </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="GUq-Nq-VYC">
                                 <rect key="frame" x="268" y="562" width="63" height="30"/>
                                 <color key="backgroundColor" white="0.0" alpha="1" colorSpace="calibratedWhite"/>
@@ -56,29 +75,6 @@ Override</string>
                                 <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Xhq-O6-s1q">
-                                <rect key="frame" x="5" y="562" width="100" height="30"/>
-                                <color key="backgroundColor" white="0.0" alpha="1" colorSpace="calibratedWhite"/>
-                                <constraints>
-                                    <constraint firstAttribute="width" constant="100" id="syk-hr-2JU"/>
-                                </constraints>
-                                <state key="normal" title="Set URL">
-                                    <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                                    <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
-                                </state>
-                                <userDefinedRuntimeAttributes>
-                                    <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
-                                        <integer key="value" value="3"/>
-                                    </userDefinedRuntimeAttribute>
-                                </userDefinedRuntimeAttributes>
-                                <connections>
-                                    <action selector="updateUrl:" destination="BYZ-38-t0r" eventType="touchUpInside" id="te0-L5-tRB"/>
-                                </connections>
-                            </button>
-                            <slider opaque="NO" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" value="0.5" minValue="0.0" maxValue="1" minimumValueImage="mute-2-24.png" maximumValueImage="volume-up-4-24.png" translatesAutoresizingMaskIntoConstraints="NO" id="cPw-aN-d6v" customClass="SNVolumeSlider">
-                                <rect key="frame" x="17" y="522" width="566" height="31"/>
-                                <color key="tintColor" red="1" green="0.50196081399917603" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
-                            </slider>
                             <visualEffectView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="4JX-p1-7QB">
                                 <rect key="frame" x="-10" y="20" width="620" height="582"/>
                                 <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" id="13z-pS-mKq">
@@ -90,12 +86,21 @@ Override</string>
                             <activityIndicatorView hidden="YES" opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" hidesWhenStopped="YES" style="whiteLarge" translatesAutoresizingMaskIntoConstraints="NO" id="Pda-Oa-pu9">
                                 <rect key="frame" x="281" y="281" width="37" height="37"/>
                             </activityIndicatorView>
+                            <view tag="-1" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="N4G-8w-SV7" userLabel="Volume View" customClass="MPVolumeView">
+                                <rect key="frame" x="19" y="532" width="562" height="30"/>
+                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                                <color key="tintColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                <accessibility key="accessibilityConfiguration" hint="Adjust volume of alerts" label="Volume">
+                                    <bool key="isElement" value="YES"/>
+                                </accessibility>
+                            </view>
                         </subviews>
                         <color key="backgroundColor" white="0.0" alpha="1" colorSpace="calibratedWhite"/>
                         <constraints>
-                            <constraint firstItem="Xhq-O6-s1q" firstAttribute="top" secondItem="cPw-aN-d6v" secondAttribute="bottom" constant="10" id="0dj-u9-cyU"/>
                             <constraint firstItem="4JX-p1-7QB" firstAttribute="centerX" secondItem="Pda-Oa-pu9" secondAttribute="centerX" id="351-Fm-B5N"/>
                             <constraint firstItem="R8v-ZL-wix" firstAttribute="bottom" secondItem="wfy-db-euE" secondAttribute="top" id="48e-bl-e24"/>
+                            <constraint firstItem="Xhq-O6-s1q" firstAttribute="top" secondItem="N4G-8w-SV7" secondAttribute="bottom" id="5GF-RN-fqz"/>
+                            <constraint firstItem="N4G-8w-SV7" firstAttribute="leading" secondItem="8bC-Xf-vdC" secondAttribute="leadingMargin" constant="3" id="6Va-iV-hLd"/>
                             <constraint firstItem="Xhq-O6-s1q" firstAttribute="baseline" secondItem="GUq-Nq-VYC" secondAttribute="baseline" id="8BQ-zd-sBH"/>
                             <constraint firstItem="94s-lY-C7V" firstAttribute="leading" secondItem="8bC-Xf-vdC" secondAttribute="leading" id="8U1-sZ-2U0"/>
                             <constraint firstItem="Pda-Oa-pu9" firstAttribute="centerY" secondItem="8bC-Xf-vdC" secondAttribute="centerY" id="9AL-vp-ng9"/>
@@ -109,16 +114,15 @@ Override</string>
                             <constraint firstItem="oVI-sD-5Pz" firstAttribute="trailing" secondItem="8bC-Xf-vdC" secondAttribute="trailingMargin" constant="10" id="WJ6-eL-taM"/>
                             <constraint firstItem="Xhq-O6-s1q" firstAttribute="leading" secondItem="8bC-Xf-vdC" secondAttribute="leadingMargin" constant="-11" id="eN2-1d-XM8"/>
                             <constraint firstItem="GUq-Nq-VYC" firstAttribute="centerX" secondItem="94s-lY-C7V" secondAttribute="centerX" id="hnu-7K-ruE"/>
+                            <constraint firstItem="N4G-8w-SV7" firstAttribute="top" secondItem="94s-lY-C7V" secondAttribute="bottom" constant="12" id="lmX-o3-LYV"/>
                             <constraint firstItem="4JX-p1-7QB" firstAttribute="top" secondItem="y3c-jy-aDJ" secondAttribute="bottom" id="o5t-uy-TW4"/>
                             <constraint firstItem="wfy-db-euE" firstAttribute="top" secondItem="oVI-sD-5Pz" secondAttribute="bottom" constant="7" id="ols-rS-zhd"/>
+                            <constraint firstItem="N4G-8w-SV7" firstAttribute="centerX" secondItem="GUq-Nq-VYC" secondAttribute="centerX" id="pkw-FL-FHE"/>
                             <constraint firstAttribute="trailing" secondItem="94s-lY-C7V" secondAttribute="trailing" id="qj6-KN-G2D"/>
                             <constraint firstItem="wfy-db-euE" firstAttribute="top" secondItem="Xhq-O6-s1q" secondAttribute="bottom" constant="8" symbolic="YES" id="qzV-zG-kAK"/>
-                            <constraint firstItem="cPw-aN-d6v" firstAttribute="leading" secondItem="8bC-Xf-vdC" secondAttribute="leadingMargin" constant="3" id="wTZ-Jw-t4b"/>
-                            <constraint firstItem="cPw-aN-d6v" firstAttribute="centerX" secondItem="GUq-Nq-VYC" secondAttribute="centerX" id="yPT-sG-bxL"/>
                         </constraints>
                     </view>
                     <connections>
-                        <outlet property="alertVolume" destination="cPw-aN-d6v" id="CG4-GZ-nCu"/>
                         <outlet property="blur" destination="4JX-p1-7QB" id="cRV-hk-tuZ"/>
                         <outlet property="loadingIndicator" destination="Pda-Oa-pu9" id="ceM-dQ-H0J"/>
                         <outlet property="nightscoutSite" destination="94s-lY-C7V" id="4Gc-hB-eiC"/>
@@ -132,8 +136,4 @@ Override</string>
             <point key="canvasLocation" x="462" y="375"/>
         </scene>
     </scenes>
-    <resources>
-        <image name="mute-2-24.png" width="24" height="24"/>
-        <image name="volume-up-4-24.png" width="24" height="24"/>
-    </resources>
 </document>

--- a/Nighscout/Base.lproj/Main.storyboard
+++ b/Nighscout/Base.lproj/Main.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="6245" systemVersion="14A389" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="6245" systemVersion="14B25" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="BYZ-38-t0r">
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6238"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
@@ -75,7 +75,7 @@ Override</string>
                                     <action selector="updateUrl:" destination="BYZ-38-t0r" eventType="touchUpInside" id="te0-L5-tRB"/>
                                 </connections>
                             </button>
-                            <slider opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" value="0.5" minValue="0.0" maxValue="1" minimumValueImage="mute-2-24.png" maximumValueImage="volume-up-4-24.png" translatesAutoresizingMaskIntoConstraints="NO" id="cPw-aN-d6v" customClass="SNVolumeSlider">
+                            <slider opaque="NO" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" value="0.5" minValue="0.0" maxValue="1" minimumValueImage="mute-2-24.png" maximumValueImage="volume-up-4-24.png" translatesAutoresizingMaskIntoConstraints="NO" id="cPw-aN-d6v" customClass="SNVolumeSlider">
                                 <rect key="frame" x="17" y="522" width="566" height="31"/>
                                 <color key="tintColor" red="1" green="0.50196081399917603" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                             </slider>
@@ -129,7 +129,7 @@ Override</string>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="607" y="366"/>
+            <point key="canvasLocation" x="462" y="375"/>
         </scene>
     </scenes>
     <resources>

--- a/Nighscout/SNVolumeSlider.h
+++ b/Nighscout/SNVolumeSlider.h
@@ -6,7 +6,9 @@
 //
 
 #import <UIKit/UIKit.h>
+#import <AVFoundation/AVAudioSession.h>
 
 @interface SNVolumeSlider : UISlider
-
+@end
+@interface MHAudioBufferPlayer : NSObject <AVAudioSessionDelegate>
 @end

--- a/Nighscout/SNVolumeSlider.m
+++ b/Nighscout/SNVolumeSlider.m
@@ -9,6 +9,7 @@
 
 #import <AudioToolbox/AudioToolbox.h>
 #import <MediaPlayer/MediaPlayer.h>
+#import <AVFoundation/AVAudioSession.h>
 
 @implementation SNVolumeSlider
 

--- a/Nighscout/ViewController.h
+++ b/Nighscout/ViewController.h
@@ -7,7 +7,7 @@
 //
 
 #import <UIKit/UIKit.h>
-#import "SNVolumeSlider.h"
+//#import "SNVolumeSlider.h"
 
 
 @interface ViewController : UIViewController <UIWebViewDelegate>
@@ -18,7 +18,7 @@
 @property (weak, nonatomic) IBOutlet UIButton *refreshUrl;
 @property (weak, nonatomic) IBOutlet UIButton *sleep;
 @property (weak, nonatomic) IBOutlet UIActivityIndicatorView *loadingIndicator;
-@property (strong, nonatomic) IBOutlet SNVolumeSlider *alertVolume;
+//@property (strong, nonatomic) IBOutlet SNVolumeSlider *alertVolume;
 @property (strong, nonatomic) IBOutlet UISwitch *screenLock;
 @property (strong, nonatomic) IBOutlet UIVisualEffectView *blur;
 

--- a/Nighscout/ViewController.m
+++ b/Nighscout/ViewController.m
@@ -8,6 +8,8 @@
 
 #import "ViewController.h"
 #import "SettingsManager.h"
+#import <MediaPlayer/MediaPlayerDefines.h>
+#import <AVFoundation/AVFoundation.h>
 
 @interface ViewController ()
 @property NSString *nightscoutUrl;
@@ -22,7 +24,11 @@
     self.defaultUrl = @"http://www.nightscout.info/wiki/welcome/nightscout-for-ios-optional";
     self.blur.hidden = YES;
     [super viewDidLoad];
-    self.alertVolume = [[SNVolumeSlider alloc] init];
+    //self.alertVolume = [[SNVolumeSlider alloc] init];
+    //AVAudioSession.sharedInstance().setCategory(AVAudioSessionCategoryPlayback, error: nil);
+    [[AVAudioSession sharedInstance] setCategory: AVAudioSessionCategoryPlayback
+                                     withOptions:0 error: nil];
+    [[AVAudioSession sharedInstance] setActive: YES withOptions: 0 error: nil];
     [self.setUrl.layer setBorderWidth:1.0];
     [self.setUrl.layer setBorderColor:[[UIColor whiteColor] CGColor]];
     [self.refreshUrl.layer setBorderWidth:1.0];

--- a/Nightscout.xcodeproj/project.pbxproj
+++ b/Nightscout.xcodeproj/project.pbxproj
@@ -8,7 +8,6 @@
 
 /* Begin PBXBuildFile section */
 		1DCF98A81A58729A005F751F /* SettingsManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 1DCF98A71A58729A005F751F /* SettingsManager.m */; };
-		809AAFBB1A3CDD4C00724B43 /* SNVolumeSlider.m in Sources */ = {isa = PBXBuildFile; fileRef = 809AAFBA1A3CDD4C00724B43 /* SNVolumeSlider.m */; };
 		809AAFBD1A3CE02F00724B43 /* MediaPlayer.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 809AAFBC1A3CE02F00724B43 /* MediaPlayer.framework */; };
 		809AAFBF1A3CE03500724B43 /* AudioToolbox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 809AAFBE1A3CE03500724B43 /* AudioToolbox.framework */; };
 		80A5F86E1A38F9EF001524BC /* Logo_180.png in Resources */ = {isa = PBXBuildFile; fileRef = 80A5F8691A38F9EF001524BC /* Logo_180.png */; };
@@ -42,8 +41,6 @@
 /* Begin PBXFileReference section */
 		1DCF98A61A58729A005F751F /* SettingsManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SettingsManager.h; sourceTree = "<group>"; };
 		1DCF98A71A58729A005F751F /* SettingsManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SettingsManager.m; sourceTree = "<group>"; };
-		809AAFB91A3CDD4C00724B43 /* SNVolumeSlider.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SNVolumeSlider.h; sourceTree = "<group>"; };
-		809AAFBA1A3CDD4C00724B43 /* SNVolumeSlider.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SNVolumeSlider.m; sourceTree = "<group>"; };
 		809AAFBC1A3CE02F00724B43 /* MediaPlayer.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MediaPlayer.framework; path = System/Library/Frameworks/MediaPlayer.framework; sourceTree = SDKROOT; };
 		809AAFBE1A3CE03500724B43 /* AudioToolbox.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AudioToolbox.framework; path = System/Library/Frameworks/AudioToolbox.framework; sourceTree = SDKROOT; };
 		80A5F8691A38F9EF001524BC /* Logo_180.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = Logo_180.png; sourceTree = "<group>"; };
@@ -114,8 +111,6 @@
 		DBC665A01A3623FB00DE1748 /* Nightscout */ = {
 			isa = PBXGroup;
 			children = (
-				809AAFB91A3CDD4C00724B43 /* SNVolumeSlider.h */,
-				809AAFBA1A3CDD4C00724B43 /* SNVolumeSlider.m */,
 				DBC665A51A3623FB00DE1748 /* AppDelegate.h */,
 				DBC665A61A3623FB00DE1748 /* AppDelegate.m */,
 				DBC665A81A3623FB00DE1748 /* ViewController.h */,
@@ -286,7 +281,6 @@
 				DBC665A71A3623FB00DE1748 /* AppDelegate.m in Sources */,
 				1DCF98A81A58729A005F751F /* SettingsManager.m in Sources */,
 				DBC665A41A3623FB00DE1748 /* main.m in Sources */,
-				809AAFBB1A3CDD4C00724B43 /* SNVolumeSlider.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -411,6 +405,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos8.0]" = "iPhone Developer";
 				INFOPLIST_FILE = Nighscout/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
@@ -426,6 +421,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos8.0]" = "iPhone Developer";
 				INFOPLIST_FILE = Nighscout/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;

--- a/Nightscout.xcodeproj/project.pbxproj
+++ b/Nightscout.xcodeproj/project.pbxproj
@@ -210,7 +210,7 @@
 				TargetAttributes = {
 					DBC6659D1A3623FB00DE1748 = {
 						CreatedOnToolsVersion = 6.1;
-						DevelopmentTeam = 653X2ET559;
+						DevelopmentTeam = DYN8SHLPKN;
 						SystemCapabilities = {
 							com.apple.BackgroundModes = {
 								enabled = 1;
@@ -219,6 +219,7 @@
 					};
 					DBC665B61A3623FB00DE1748 = {
 						CreatedOnToolsVersion = 6.1;
+						DevelopmentTeam = DYN8SHLPKN;
 						TestTargetID = DBC6659D1A3623FB00DE1748;
 					};
 				};
@@ -404,13 +405,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos8.0]" = "iPhone Developer";
 				INFOPLIST_FILE = Nighscout/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_NAME = Nightscout;
 				PROVISIONING_PROFILE = "";
-				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGETED_DEVICE_FAMILY = 1;
 			};
 			name = Debug;
 		};
@@ -419,13 +420,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos8.0]" = "iPhone Developer";
 				INFOPLIST_FILE = Nighscout/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_NAME = Nightscout;
 				PROVISIONING_PROFILE = "";
-				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGETED_DEVICE_FAMILY = 1;
 			};
 			name = Release;
 		};


### PR DESCRIPTION
I removed the volume slider and the deprecated libraries that went with it. I added a MediaPlayer volume control to replace it, and activate the audio session automatically. The hardware volume buttons still work, and you can now specify an airplay destination, but I haven't quite gotten that to work 100% yet. If it won't work, I can always disable the airplay selector later. You'll probably want to filter out the changes to the developer ID, but I thought I would send this back to you if you are interested. The code still needs a tiny amount of cleanup, but it's 4am, and I'll clean it up later.
